### PR TITLE
Fix anyone being able to use /tdm_set_max_score

### DIFF
--- a/tdm/scripts/teamdeathmatch.py
+++ b/tdm/scripts/teamdeathmatch.py
@@ -240,9 +240,8 @@ class TDMServer(TeamServer):
 def get_class():
     return TDMServer
 
-
-@admin
 @command
+@admin
 def tdm_set_max_score(script, score):
     """Set the kill count per round."""
     try:


### PR DESCRIPTION
Apparently, order of @command and @restrict matters.