### PR TITLE
fix invalid boss race in mission data

### DIFF
--- a/koth/scripts/kingofthehill.py
+++ b/koth/scripts/kingofthehill.py
@@ -609,7 +609,7 @@ class KotHServer(ServerScript):
         mission.something3 = 1
         mission.mission_id = 1
         mission.something5 = 1
-        mission.monster_id = 1000  # How is this monster id when its an int32?
+        mission.monster_id = 0
         mission.quest_level = 500
         mission.something8 = 1
         mission.state = 1


### PR DESCRIPTION
*the reason i care about this at all is because i am working on a networking library for cubeworld that is very strict about data validity, and it breaks on cuwo servers because of this*

it was falsely assumed that `monster_id` refers to the guid of the boss (hence the comment expressing confusion), when it actually represents the `race` (eg undead) of the boss, which is sometimes used in the mission text on the right side of the screen (eg "defeat the _undead_ in [dungeon]"). since this mission doesn't have such text, it doesn't matter what value is used here so it should at least be a valid one (0-156). i decided to default to 0 which represents a male elf